### PR TITLE
Fix/latent ros deps

### DIFF
--- a/src/test.cpp
+++ b/src/test.cpp
@@ -22,7 +22,6 @@
 #include <fstream>
 #include <math.h>
 #include <iostream>
-#include <ros/ros.h>
 #include "ur10driver.h"
 
 void marcTest(UR10Driver& driver){

--- a/src/ur10driver.cpp
+++ b/src/ur10driver.cpp
@@ -4,6 +4,7 @@
 #include <thread>
 #include <math.h>
 #include <fstream>
+#include <iostream>
 
 #include "ur_modern_driver/pipeline.h"
 #include "ur_modern_driver/ur/lowbandwidth_trajectory_follower.h"
@@ -154,11 +155,11 @@ std::array<double, 6> UR10Driver::get_qdot_now(){
 }
 
 void UR10Driver::executeTrajectory(std::vector<TrajectoryPoint> &trajectory, std::atomic<bool> &interrupt){
-  cout <<"** START" <<endl;
+  std::cout <<"** START" <<endl;
   self->traj_follower->start();
-  cout <<"** EXECUTE" <<endl;
+  std::cout <<"** EXECUTE" <<endl;
   self->traj_follower->execute(trajectory, interrupt);
-  cout <<"** STOP" <<endl;
+  std::cout <<"** STOP" <<endl;
   self->traj_follower->stop();
-  cout <<"** DONE" <<endl;
+  std::cout <<"** DONE" <<endl;
 }

--- a/src/ur10driver.cpp
+++ b/src/ur10driver.cpp
@@ -1,4 +1,3 @@
-#include <ros/ros.h>
 #include <chrono>
 #include <cstdlib>
 #include <string>


### PR DESCRIPTION
There were two unused includes of ros.h in the code, which kept it from compiling in a ROS-free environment. Also, the calls of `cout` did not compile, since they were lacking the `std::` namespace prefix and the `iostream` header.